### PR TITLE
Ip block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+t/
+Gemfile*
+*.gem
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ t/
 Gemfile*
 *.gem
 tags
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ puts records.first.record[:name]
 puts records
 ```
 
+Get firewall rules:
+
+``` ruby
+all_rules =  zones.first.firewall_rules.all
+block_rules = zones.first.firewall_rules.all("block")  # or "whitelist" or "challenge"
+```
+
+Get blocked ips:
+
+``` ruby
+block_rules = zones.first.firewall_rules.all("block") 
+blocked_ips = zones.first.firewall_rules.firewalled_ips(block_rules)
+```
+
+Block an ip:
+
+``` ruby
+# ip = "nnn.nnn.nnn.nnn"
+# note: "some note about the block"
+data = {"mode":"block","configuration":{"target":"ip","value":"#{ip}"},"notes":"#{note} #{Time.now.strftime("%m/%d/%y")} "}
+response = zones.first.firewall_rules.post(data.to_json, content_type: 'application/json')
+
+```
 ## Contributing
 
 1. Fork it
@@ -103,3 +126,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+

--- a/cloudflare.gemspec
+++ b/cloudflare.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "byebug"
 end

--- a/cloudflare.gemspec
+++ b/cloudflare.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "byebug"
 end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -27,29 +27,29 @@ require 'rest-client'
 require_relative 'response'
 
 module Cloudflare
-	DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
-	TIMEOUT = 10 # Default is 5 seconds
-	
-	class Resource < RestClient::Resource
-		# @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
-		# @param email [String] `X-Auth-Email`, your email address for the account.
-		def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
-			headers = options[:headers] || {}
-			
-			if email.nil?
-				headers['X-Auth-User-Service-Key'] = key
-			else
-				headers['X-Auth-Key'] = key
-				headers['X-Auth-Email'] = email
-			end
-			
-			# Convert HTTP API responses to our own internal response class:
-			super(url, headers: headers, accept: 'application/json', **options) do |response|
-				Response.new(response.request.url, response.body)
-			end
-		end
-	end
-	
-	class Connection < Resource
-	end
+  DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
+  TIMEOUT = 10 # Default is 5 seconds
+
+  class Resource < RestClient::Resource
+    # @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
+    # @param email [String] `X-Auth-Email`, your email address for the account.
+    def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
+      headers = options[:headers] || {}
+
+      if email.nil?
+        headers['X-Auth-User-Service-Key'] = key
+      else
+        headers['X-Auth-Key'] = key
+        headers['X-Auth-Email'] = email
+      end
+
+      # Convert HTTP API responses to our own internal response class:
+      super(url, headers: headers, accept: 'application/json', **options) do |response|
+        Response.new(response.request.url, response.body)
+      end
+    end
+  end
+
+  class Connection < Resource
+  end
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-	VERSION = '3.0.0'
+  VERSION = '3.0.2'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.0.4'
+  VERSION = '3.1.0'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.0.3'
+  VERSION = '3.0.4'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.0.2'
+  VERSION = '3.0.3'
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -22,7 +22,6 @@
 # added firewall rules support: david rosenbloom|davidr@artifactory.com|artifactory
 #
 require_relative 'connection'
-require 'byebug'
 module Cloudflare
   class Connection < Resource
     def zones

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -118,6 +118,11 @@ module Cloudflare
       raise "Bad ip arg: #{ip}" if ip and !(ip =~ /[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*/)    # TODO: add ranges, e.g. /24
     end
 
+    def firewall_rules_resource
+      FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
+    end
+
+
     def firewall_rules(mode = nil, ip = nil, notes = nil)
       # 4 - rules request
       validate_args(mode, ip)
@@ -142,7 +147,6 @@ module Cloudflare
     def firewalled_ips(rules)
       rules.collect {|r| r.record[:configuration][:value]}
     end
-
 
     def to_s
       @record[:name]

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -18,7 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+# require 'byebug'
 require_relative 'connection'
 
 module Cloudflare
@@ -94,6 +94,8 @@ module Cloudflare
     attr :zone
 
     def all
+      # byebug
+      # ?scope_type=organization&mode=block&per_page=100&page=#{page}\
       self.get.results.map{|record| WAFAccessRule.new(concat_urls(url, record[:id]), record, **options)}
     end
 
@@ -128,7 +130,7 @@ module Cloudflare
     end
 
     def waf_access_rules
-      @waf_access_rules ||= WAFAccessRules.new(concat_urls(url, 'firewall/access_rules/rules'), self, **options)
+      @waf_access_rules ||= WAFAccessRules.new(concat_urls(url, 'firewall/access_rules/rules?scope_type=organization&mode=block&per_page=100'), self, **options)
     end
 
 

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -22,89 +22,138 @@
 require_relative 'connection'
 
 module Cloudflare
-	class Connection < Resource
-		def zones
-			@zones ||= Zones.new(concat_urls(url, 'zones'), options)
-		end
-	end
-	
-	class DNSRecord < Resource
-		def initialize(url, record = nil, **options)
-			super(url, **options)
-			
-			@record = record || self.get.result
-		end
-		
-		attr :record
-		
-		def to_s
-			"#{@record[:name]} #{@record[:type]} #{@record[:content]}"
-		end
-	end
-	
-	class DNSRecords < Resource
-		def initialize(url, zone, **options)
-			super(url, **options)
-			
-			@zone = zone
-		end
-		
-		attr :zone
-		
-		def all
-			self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
-		end
-		
-		def find_by_name(name)
-			response = self.get(params: {name: name})
-			
-			unless response.empty?
-				record = response.results.first
-				
-				DNSRecord.new(concat_urls(url, record[:id]), record, **options)
-			end
-		end
-		
-		def find_by_id(id)
-			DNSRecord.new(concat_urls(url, id), **options)
-		end
-	end
-	
-	class Zone < Resource
-		def initialize(url, record = nil, **options)
-			super(url, **options)
-			
-			@record = record || self.get.result
-		end
-		
-		attr :record
-		
-		def dns_records
-			@dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
-		end
-		
-		def to_s
-			@record[:name]
-		end
-	end
-	
-	class Zones < Resource
-		def all
-			self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
-		end
-		
-		def find_by_name(name)
-			record = self.get(params: {name: name}).result
-			
-			unless response.empty?
-				record = response.results.first
-				
-				Zone.new(concat_urls(url, record[:id]), record, **options)
-			end
-		end
-		
-		def find_by_id(id)
-			Zone.new(concat_urls(url, id), **options)
-		end
-	end
+  class Connection < Resource
+    def zones
+      @zones ||= Zones.new(concat_urls(url, 'zones'), options)
+    end
+  end
+
+  class DNSRecord < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
+
+      @record = record || self.get.result
+    end
+
+    attr :record
+
+    def to_s
+      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+    end
+  end
+
+  class DNSRecords < Resource
+    def initialize(url, zone, **options)
+      super(url, **options)
+
+      @zone = zone
+    end
+
+    attr :zone
+
+    def all
+      self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+      response = self.get(params: {name: name})
+
+      unless response.empty?
+        record = response.results.first
+
+        DNSRecord.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
+
+    def find_by_id(id)
+      DNSRecord.new(concat_urls(url, id), **options)
+    end
+  end
+#################
+  class WAFAccessRule < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
+
+      @record = record || self.get.result
+    end
+
+    attr :record
+
+    def to_s
+      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+    end
+  end
+
+  class WAFAccessRules < Resource
+    def initialize(url, zone, **options)
+      super(url, **options)
+
+      @zone = zone
+    end
+
+    attr :zone
+
+    def all
+      self.get.results.map{|record| WAFAccessRule.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+      response = self.get(params: {name: name})
+
+      unless response.empty?
+        record = response.results.first
+
+        WAFAccessRule.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
+
+    def find_by_id(id)
+      WAFAccessRule.new(concat_urls(url, id), **options)
+    end
+  end
+
+
+##################
+  class Zone < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
+
+      @record = record || self.get.result
+    end
+
+    attr :record
+
+    def dns_records
+      @dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
+    end
+
+    def waf_access_rules
+      @waf_access_rules ||= WAFAccessRules.new(concat_urls(url, 'firewall/access_rules/rules'), self, **options)
+    end
+
+
+    def to_s
+      @record[:name]
+    end
+  end
+
+  class Zones < Resource
+    def all
+      self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+      record = self.get(params: {name: name}).result
+
+      unless response.empty?
+        record = response.results.first
+
+        Zone.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
+
+    def find_by_id(id)
+      Zone.new(concat_urls(url, id), **options)
+    end
+  end
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -139,8 +139,8 @@ module Cloudflare
       results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
     end
 
-    def firewalled_ips(mode)
-      firewall_rules(mode).all.collect {|r| r.record[:configuration][:value]}
+    def firewalled_ips(rules)
+      rules.collect {|r| r.record[:configuration][:value]}
     end
 
 


### PR DESCRIPTION
Aside from the tabs/spaces debacle, enable firewall rules access. Pagination to override default 20 records minimum is implemented for firewall rules, deviating from the original model for dns_records. afaict it would make sense to apply such functionality to dns_records as well, but that is not addressed in this PR.