### PR TITLE
Maintenance: Remove EOL rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 dist: trusty
 cache: bundler
 rvm:
-- 2.0
-- 2.1
-- 2.2
 - 2.3
 - 2.4
 - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache: bundler
 rvm:
 - 2.3
 - 2.4
+- 2.5
+- 2.6
 - jruby-head
 - ruby-head
 matrix:


### PR DESCRIPTION
- remove EOL rubies from `travis.yml`
- add new rubies (2.5, 2.6) to `travis.yml`

check Ruby version maintenance status here: https://www.ruby-lang.org/en/downloads/branches/