### PR TITLE
Feature: Add purge_cache API call for zone

### DIFF
--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -32,6 +32,7 @@ require_relative 'response'
 module Cloudflare
   DEFAULT_URL = 'https://api.cloudflare.com/client/v4/'
   TIMEOUT = 10 # Default is 5 seconds
+  DEFAULT_HEADERS = { 'Content-Type' => 'application/json' }.freeze
 
   class Resource < RestClient::Resource
     include Enumerable
@@ -39,7 +40,7 @@ module Cloudflare
     # @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
     # @param email [String] `X-Auth-Email`, your email address for the account.
     def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
-      headers = options[:headers] || {}
+      headers = options[:headers] || DEFAULT_HEADERS.dup
 
       if email.nil?
         headers['X-Auth-User-Service-Key'] = key

--- a/spec/cloudflare/zone_spec.rb
+++ b/spec/cloudflare/zone_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe 'Cloudflare DNS Zones' do
     expect(zones).to be_any
   end
 
+  describe Cloudflare::Zone, order: :defined do
+    before(:each) do
+      stub_get_zones
+      stub_purge_cache
+    end
+
+    let(:zone) { connection.zones.all.first }
+
+    describe '#purge_cache' do
+      it 'should purge cache' do
+        expect(zone.purge_cache).to eq(true)
+      end
+    end
+  end
+
   describe Cloudflare::DNSRecords, order: :defined do
     before(:each) do
       stub_get_zones

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -142,6 +142,12 @@ def stub_create_rule(mode, ip, note)
       .to_return(status: 200, body: cf_results(cf_access_rule(mode, ip, notes)), headers: {})
 end
 
+def stub_purge_cache
+  stub_request(:post, "#{base_url}/zones/#{zone_id}/purge_cache")
+      .with(cf_headers)
+      .to_return(status: 200, body: cf_results(id: zone_id), headers: {})
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
This PR adds support for purging cache for a particular zone. See Cloudflare [documentation](https://api.cloudflare.com/#zone-purge-all-files).

I've implemented this to fix https://github.com/leighmcculloch/middleman-cdn/issues/17 which apparently broke the `middleman-cdn` gem.

Not sure the rspec test is useful though. I have no idea how to test it. 🤔 