### PR TITLE
Retrieve all zones through pagination

### DIFF
--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -56,7 +56,7 @@ module Cloudflare
 
     def paginate(obj, url, url_args = '')
       page = 1
-      page_size = 100
+      page_size = 50
       results = []
 
       # fetch and aggregate all pages

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -173,7 +173,8 @@ module Cloudflare
 
   class Zones < Resource
     def all
-      get.results.map { |record| Zone.new(concat_urls(url, record[:id]), record, **options) }
+      results = paginate(Zone, url)
+      results.map { |record| Zone.new(concat_urls(url, record[:id]), record, **options) }
     end
 
     def find_by_name(name)

--- a/spec/fake_cloudflare/cloudflare.rb
+++ b/spec/fake_cloudflare/cloudflare.rb
@@ -3,7 +3,7 @@
 require 'sinatra/base'
 
 class FakeCloudFlare < Sinatra::Base
-  get '/zones/:id/dns_records/?page=1&per_page=100&scope_type=organization' do
+  get '/zones/:id/dns_records/?page=1&per_page=50&scope_type=organization' do
     json_response 200, 'get_all_zones.json'
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ def stub_get_dns_records
       "zone_id": zone_id,
       "zone_name": 'example.com'
   }
-  stub_request(:get, "#{base_url}/zones/#{zone_id}/dns_records/?page=1&per_page=100&scope_type=organization")
+  stub_request(:get, "#{base_url}/zones/#{zone_id}/dns_records/?page=1&per_page=50&scope_type=organization")
       .with(cf_headers)
       .to_return(status: 200,
                  body: cf_results([dns_record]),
@@ -110,7 +110,7 @@ def stub_find_rule_by_value(ip:)
 end
 
 def stub_list_access_rules(page, rules)
-  query = URI.encode_www_form(page: page, per_page: 100, scope_type: :organization)
+  query = URI.encode_www_form(page: page, per_page: 50, scope_type: :organization)
   stub_request(:get, "#{base_url}/zones/#{zone_id}/firewall/access_rules/rules/?#{query}")
       .with(cf_headers)
       .to_return(status: 200, body: cf_results(rules), headers: {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ def zone_id
 end
 
 def stub_get_zones
-  stub_request(:get, "#{base_url}/zones")
+  stub_request(:get, "#{base_url}/zones/?page=1&per_page=50&scope_type=organization")
       .with(cf_headers)
       .to_return(status: 200, body: cf_results([{
                                                     name: 'example.com',


### PR DESCRIPTION
# Why
I have multiple zones associated with my Cloudflare account. When retrieving the zones through the library, I noticed that only a subset of zones were retrieved.

Currently, only 20 Zones will be retrieved with `connection.zones.all`, which is the default value of `per_page`.

# What
This PR fixes the above issue and retrieves all the zones.

Also, the `per_page` limit is 50 (https://api.cloudflare.com/#zone-list-zones), and the values have been updated in this PR as well.

# How
By applying the `paginate` method in `Zones#all`, we can retrieve all the records in the same manner as DNSRecords and FirewallRules are retrieved.