### PR TITLE
Add ruby v2.2 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - gem install bundler
 
 rvm:
+- 2.2
 - 2.3
 - 2.4
 - 2.5


### PR DESCRIPTION
Add ruby v2.2 to Travis CI. Remove incompatible `&` feature usage.