### PR TITLE
add preload option to Zones#all

### DIFF
--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -186,9 +186,9 @@ module Cloudflare
 	end
 
 	class Zones < Resource
-		def all
+		def all(preload = false)
 			results = paginate(Zone, url)
-			results.map {|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
+			results.map {|record| Zone.new(concat_urls(url, record[:id]), record, preload, **options)}
 		end
 
 		def find_by_name(name)


### PR DESCRIPTION
I want to get all zone name, but now it will be very boring code.
So add new option and Zones#all will return Zone class instances which contains record data.